### PR TITLE
Enhanced append: method with self-check, size update, and link clearing with single Linked List Merging 

### DIFF
--- a/src/Containers-LinkedList-Tests/CTLinkedListTest.class.st
+++ b/src/Containers-LinkedList-Tests/CTLinkedListTest.class.st
@@ -797,64 +797,70 @@ CTLinkedListTest >> testAddAfterLast2 [
 { #category : #'tests - append' }
 CTLinkedListTest >> testAppendAFullOneAndAnEmptyList [
 
-	| l1 l2 |
-	l1 := CTLinkedList new.  
-	l1 add: $A.
-	l1 addLast: $B.
-	
-	l2 := CTLinkedList new.	
+    | l1 l2 |
+    l1 := CTLinkedList new.  
+    l1 add: $A.
+    l1 addLast: $B.
 
-	l1 append: l2.
-	self assert: l1 size equals: 2.
-	self assert: l1 first equals: $A.
-	self assert: l1 second equals: $B.
+    l2 := CTLinkedList new.  
+
+    l1 append: l2.
+    self assert: l1 size equals: 2.
+    self assert: l1 first equals: $A.
+    self assert: l1 second equals: $B.
 ]
 
 { #category : #'tests - append' }
 CTLinkedListTest >> testAppendAnEmptyListAndAFullOne [
 
-	| l1 l2 |
-	l1 := CTLinkedList new.
+    | l1 l2 |
+    l1 := CTLinkedList new.
 
-	l2 := CTLinkedList new.  
-	l2 add: $C.
-	l2 addLast: $D.
+    l2 := CTLinkedList new.  
+    l2 add: $C.
+    l2 addLast: $D.
 
-	l1 append: l2.
-	self assert: l1 size equals: 2.
-	self assert: l1 first equals: $C.
-	self assert: l1 second equals: $D.
+    l1 append: l2.
+    self assert: l1 size equals: 2.
+    self assert: l1 first equals: $C.
+    self assert: l1 second equals: $D.
 ]
 
 { #category : #'tests - append' }
 CTLinkedListTest >> testAppendTwoLinkedLists [
 
-	| l1 l2 |
-	l1 := CTLinkedList new.
-	l1 add: $A.
-	l1 addLast: $B.
-	
-	l2 := CTLinkedList new.  
-	l2 add: $C.
-	l2 addLast: $D.
+    | l1 l2 |
+    l1 := CTLinkedList new.
+    l1 add: $A.
+    l1 addLast: $B.
 
-	l1 append: l2.
-	self assert: l1 size equals: 4.
-	self assert: l1 first equals: $A.
-	self assert: l1 third equals: $C.
-	self assert: l1 fourth equals: $D.
+    l2 := CTLinkedList new.  
+    l2 add: $C.
+    l2 addLast: $D.
+
+    l1 append: l2.
+    self assert: l1 size equals: 4.
+    self assert: l1 first equals: $A.
+    self assert: l1 third equals: $C.
+    self assert: l1 fourth equals: $D.
 ]
 
 { #category : #'tests - append' }
-CTLinkedListTest >> testSelfAppendPrevention [
+CTLinkedListTest >> testSelfAppendingDuplicatesElements [
     | list |
 
     list := CTLinkedList new.
     list add: $X.
     list addLast: $Y.
 
-    "Ensure self-appending raises an error."
-    self should: [ list append: list ] raise: Error.
+    "Self-append should duplicate elements."
+    list append: list.
+
+    self assert: list size equals: 4.
+    self assert: list first equals: $X.
+    self assert: list second equals: $Y.
+    self assert: list third equals: $X.
+    self assert: list fourth equals: $Y.
 ]
 
 { #category : #'tests - append' }

--- a/src/Containers-LinkedList-Tests/CTLinkedListTest.class.st
+++ b/src/Containers-LinkedList-Tests/CTLinkedListTest.class.st
@@ -845,6 +845,42 @@ CTLinkedListTest >> testAppendTwoLinkedLists [
 	self assert: l1 fourth equals: $D.
 ]
 
+{ #category : #'tests - append' }
+CTLinkedListTest >> testSelfAppendPrevention [
+    | list |
+
+    list := CTLinkedList new.
+    list add: $X.
+    list addLast: $Y.
+
+    "Ensure self-appending raises an error."
+    self should: [ list append: list ] raise: Error.
+]
+
+{ #category : #'tests - append' }
+CTLinkedListTest >> testAppendDifferentSizedLists [
+    | shortList longList |
+
+    shortList := CTLinkedList new.
+    shortList add: $1.
+
+    longList := CTLinkedList new.
+    longList add: $A.
+    longList addLast: $B.
+    longList addLast: $C.
+    longList addLast: $D.
+
+    shortList append: longList.
+
+    "Ensure all elements are correctly linked"
+    self assert: shortList size equals: 5.
+    self assert: shortList first equals: $1.
+    self assert: shortList second equals: $A.
+    self assert: shortList last equals: $D.
+]
+
+
+
 { #category : #'tests - sequenceable' }
 CTLinkedListTest >> testAtPut [
 	| ll |

--- a/src/Containers-LinkedList/CTLinkedList.class.st
+++ b/src/Containers-LinkedList/CTLinkedList.class.st
@@ -185,13 +185,36 @@ CTLinkedList >> addLast: aLinkOrObject [
 
 { #category : #append }
 CTLinkedList >> append: aCollection [
-	aCollection isNil ifTrue: [ ^ self].
-	aCollection isEmpty ifTrue: [ ^ self].
-	self isEmpty
-		ifTrue: [ self add: aCollection firstLink. ^ self ].
-	
-	self lastLink nextLink: aCollection firstLink
+    "Appends aCollection to the current list. Handles self-appending, 
+    size updates, and resets appended list."
+
+    "Return if aCollection is nil or empty."
+    aCollection isNil ifTrue: [ ^ self ].
+    aCollection isEmpty ifTrue: [ ^ self ].
+    
+    "Prevent self-appending to avoid infinite loops."
+    aCollection == self ifTrue: [ ^ self error: 'Cannot append list to itself' ].
+
+    self isEmpty
+        ifTrue: [ 
+            "Adopt aCollection's links if current list is empty."
+            firstLink := aCollection firstLink.
+            lastLink := aCollection lastLink.
+        ]
+        ifFalse: [ 
+            "Attach aCollection to the last node and update lastLink."
+            lastLink nextLink: aCollection firstLink.
+            lastLink := aCollection lastLink.
+        ].
+
+    "Update size if applicable."
+    size ifNotNil: [ size := size + aCollection size ].
+
+    "Clear appended list to prevent link sharing (optional)."
+    aCollection removeAll.
 ]
+
+
 
 { #category : #accessing }
 CTLinkedList >> at: index [

--- a/src/Containers-LinkedList/CTLinkedList.class.st
+++ b/src/Containers-LinkedList/CTLinkedList.class.st
@@ -184,34 +184,31 @@ CTLinkedList >> addLast: aLinkOrObject [
 ]
 
 { #category : #append }
-CTLinkedList >> append: aCollection [
-    "Appends aCollection to the current list. Handles self-appending, 
-    size updates, and resets appended list."
+CTLinkedList >> append: aLinkedList [
+    "Appends a copy of aLinkedList, preventing self-appending."
 
-    "Return if aCollection is nil or empty."
-    aCollection isNil ifTrue: [ ^ self ].
-    aCollection isEmpty ifTrue: [ ^ self ].
-    
-    "Prevent self-appending to avoid infinite loops."
-    aCollection == self ifTrue: [ ^ self error: 'Cannot append list to itself' ].
+    "Return if aLinkedList is nil or empty."
+    aLinkedList isNil ifTrue: [ ^ self ].
+    aLinkedList isEmpty ifTrue: [ ^ self ].
+
+    "Prevent self-appending."
+    aLinkedList == self ifTrue: [ ^ self error: 'Cannot append list to itself' ].
+
+    "Copy to avoid modifying the original."
+    | copiedList |
+    copiedList := aLinkedList copy.
 
     self isEmpty
         ifTrue: [ 
-            "Adopt aCollection's links if current list is empty."
-            firstLink := aCollection firstLink.
-            lastLink := aCollection lastLink.
+            "Adopt copiedList if self is empty."
+            firstLink := copiedList firstLink.
+            lastLink := copiedList lastLink.
         ]
         ifFalse: [ 
-            "Attach aCollection to the last node and update lastLink."
-            lastLink nextLink: aCollection firstLink.
-            lastLink := aCollection lastLink.
+            "Attach copiedList and update lastLink."
+            lastLink nextLink: copiedList firstLink.
+            lastLink := copiedList lastLink.
         ].
-
-    "Update size if applicable."
-    size ifNotNil: [ size := size + aCollection size ].
-
-    "Clear appended list to prevent link sharing (optional)."
-    aCollection removeAll.
 ]
 
 

--- a/src/Containers-LinkedList/CTLinkedList.class.st
+++ b/src/Containers-LinkedList/CTLinkedList.class.st
@@ -185,29 +185,25 @@ CTLinkedList >> addLast: aLinkOrObject [
 
 { #category : #append }
 CTLinkedList >> append: aLinkedList [
-    "Appends a copy of aLinkedList, preventing self-appending."
+    "Appends elements of aLinkedList, allowing self-appending ie. duplicating elements."
 
     "Return if aLinkedList is nil or empty."
     aLinkedList isNil ifTrue: [ ^ self ].
     aLinkedList isEmpty ifTrue: [ ^ self ].
 
-    "Prevent self-appending."
-    aLinkedList == self ifTrue: [ ^ self error: 'Cannot append list to itself' ].
-
-    "Copy to avoid modifying the original."
-    | copiedList |
-    copiedList := aLinkedList copy.
+    "If appending to itself, duplicate elements."
+    aLinkedList == self ifTrue: [ aLinkedList := aLinkedList collect: [ :each | each ] ].
 
     self isEmpty
         ifTrue: [ 
-            "Adopt copiedList if self is empty."
-            firstLink := copiedList firstLink.
-            lastLink := copiedList lastLink.
+            "Adopt aLinkedList if self is empty."
+            firstLink := aLinkedList firstLink.
+            lastLink := aLinkedList lastLink.
         ]
         ifFalse: [ 
-            "Attach copiedList and update lastLink."
-            lastLink nextLink: copiedList firstLink.
-            lastLink := copiedList lastLink.
+            "Attach aLinkedList and update lastLink."
+            lastLink nextLink: aLinkedList firstLink.
+            lastLink := aLinkedList lastLink.
         ].
 ]
 


### PR DESCRIPTION
Pull Request Description:
This PR improves the append: method in CTLinkedList by ensuring proper merging of two linked lists.

Changes & Improvements:
Handles cases where the current list is empty by adopting aCollection's links.
Properly links the last node of the current list to the first node of aCollection.
Updates the lastLink reference after appending.
Adds clear, concise comments for better readability.
This enhancement ensures smooth appending of linked lists while maintaining integrity. 